### PR TITLE
Use brick 1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,16 +35,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668231603,
-        "narHash": "sha256-/4br947zgRqABb52iLF4DCHgD49Fw5aQ6/IdTwaM95E=",
+        "lastModified": 1670631171,
+        "narHash": "sha256-alI61NWTLKyX5yxXGNjcI6gbSgiZzJ9DS76ZGb9T/4Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d8f2c4d846a2e65ad3f5a5e842b672f0b81588a2",
+        "rev": "54a348728f5bee66b996bd5f8aef52b52706c41f",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
+        "ref": "haskell-updates",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/haskell-updates";
     flake-utils.url = "github:numtide/flake-utils/master";
     flake-compat = {
       url = "github:edolstra/flake-compat/master";

--- a/nix-tree.cabal
+++ b/nix-tree.cabal
@@ -37,6 +37,7 @@ common common-options
                       ScopedTypeVariables
                       NumericUnderscores
                       MultiWayIf
+                      TemplateHaskell
   other-modules:      NixTree.PathStats
                       NixTree.StorePath
                       NixTree.App
@@ -47,21 +48,19 @@ common common-options
   build-depends:      base
                     , relude
                     , aeson
-                    , brick >= 0.64
+                    , brick >= 1 && < 2
                     , bytestring
                     , containers
                     , clock
-                    , deepseq
                     , filepath
-                    , hashable
                     , hrfsize
                     , text
-                    , transformers
                     , typed-process
                     , unordered-containers
                     , vty
                     , directory
                     , optparse-applicative
+                    , microlens
 
 executable nix-tree
   import:             common-options

--- a/src/NixTree/App.hs
+++ b/src/NixTree/App.hs
@@ -276,12 +276,14 @@ app =
                 put s {aeOpenModal = Just $ ModalSearch l r (B.listMoveUp xs)}
           (B.VtyEvent (V.EvKey V.KLeft []), Just (ModalSearch l r xs)) ->
             put
-              s { aeOpenModal =
+              s
+                { aeOpenModal =
                     Just $ ModalSearch (T.dropEnd 1 l) (T.takeEnd 1 l <> r) (B.listMoveUp xs)
                 }
           (B.VtyEvent (V.EvKey V.KRight []), Just (ModalSearch l r xs)) ->
             put
-              s { aeOpenModal =
+              s
+                { aeOpenModal =
                     Just $ ModalSearch (l <> T.take 1 r) (T.drop 1 r) (B.listMoveUp xs)
                 }
           (B.VtyEvent (V.EvKey (V.KChar c) []), Just (ModalSearch l r _))
@@ -304,11 +306,12 @@ app =
                 put s {aeOpenModal = Nothing}
           -- handle our events
           (B.AppEvent (EventTick t), _) ->
-            let new = s {aeCurrTime = t} in do
-            put new
-            if timePassedSinceSortOrderChange new <= sum (replicate 2 sortOrderChangeHighlightPeriod)
-              then return ()
-              else B.continueWithoutRedraw
+            let new = s {aeCurrTime = t}
+             in do
+                  put new
+                  if timePassedSinceSortOrderChange new <= sum (replicate 2 sortOrderChangeHighlightPeriod)
+                    then return ()
+                    else B.continueWithoutRedraw
           -- ignore otherwise
           _ ->
             return (),


### PR DESCRIPTION
https://hackage.haskell.org/package/brick/changelog

`brick` 1.0 refactored event handling to use MonadState, and some functions now expect to be run by `zoom`ing on a lens. In order not to add a dependency on the `lens` library I made a `_ModalWhyDepends` traversal myself and pulled the rest from `microlens` (which brick depends on).

Tested, everything seems to work as before.

Breaks the Nix build, but will be fixed as soon as https://github.com/NixOS/nixpkgs/pull/202022#issuecomment-1343646520 lands.