### PR TITLE
Add example for nixos

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ nix-tree --derivation '.#'
 nix-tree --derivation 'nixpkgs#asciiquarium'
 ```
 
+Run `nix-tree` on your current nixos system:
+
+```bash
+nix-tree /nix/var/nix/profiles/system
+```
+
 ## Contributing
 
 All contributions, issues and feature requests are welcome.


### PR DESCRIPTION
I added an example to the README, that runs nix-tree on /nix/var/nix/profiles/system, which symlinks to your current profile.

I used that today to debug problems with python-2 being marked insecure and failing my build without indicating what the problem was.

`nix-tree` was a big help to find the problem, thank you for that :heart: 