### PR TITLE
brick 2, optparse-applicative 0.18

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -38,16 +38,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704626572,
-        "narHash": "sha256-VwRTEKzK4wSSv64G+g3RLF3t6yBHrhR2VK3kZ5UWisU=",
+        "lastModified": 1705312483,
+        "narHash": "sha256-iyEgiTs/nOxdOZyYbfbdlafooadA04qd2Cydb0QWsD8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "24fe8bb4f552ad3926274d29e083b79d84707da6",
+        "rev": "83387128d7a9fe25d79173dd9c5f59b2e3d48f99",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
+        "ref": "haskell-updates",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/haskell-updates";
     flake-utils.url = "github:numtide/flake-utils/main";
     flake-compat = {
       url = "github:edolstra/flake-compat/master";

--- a/nix-tree.cabal
+++ b/nix-tree.cabal
@@ -48,7 +48,7 @@ common common-options
   build-depends:      base
                     , relude
                     , aeson
-                    , brick >= 1 && < 2
+                    , brick >= 2
                     , bytestring
                     , containers
                     , clock
@@ -58,6 +58,7 @@ common common-options
                     , typed-process
                     , unordered-containers
                     , vty
+                    , vty-unix
                     , directory
                     , optparse-applicative
                     , microlens

--- a/src/NixTree/App.hs
+++ b/src/NixTree/App.hs
@@ -13,6 +13,7 @@ import qualified Data.Sequence as S
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Graphics.Vty as V
+import qualified Graphics.Vty.Platform.Unix as V
 import Lens.Micro (Traversal', _Just)
 import qualified NixTree.Clipboard as Clipboard
 import NixTree.PathStats

--- a/src/NixTree/Main.hs
+++ b/src/NixTree/Main.hs
@@ -42,8 +42,10 @@ optsParser =
                 ( Opts.metavar "INSTALLABLE"
                     <> Opts.helpDoc
                       ( Just $
-                          "A store path or a flake reference."
-                            Opts.<$$> "Paths default to \"~/.nix-profile\" and \"/var/run/current-system\""
+                          Opts.vcat
+                            [ "A store path or a flake reference.",
+                              "Paths default to \"~/.nix-profile\" and \"/var/run/current-system\""
+                            ]
                       )
                 )
           )
@@ -53,8 +55,10 @@ optsParser =
 
     keybindingsHelp :: Opts.Doc
     keybindingsHelp =
-      "Keybindings:"
-        Opts.<$$> (Opts.indent 2 . Opts.vsep $ map (Opts.text . toString) (lines helpText))
+      Opts.vcat
+        [ "Keybindings:",
+          Opts.indent 2 . Opts.vsep $ map (Opts.pretty . toString) (lines helpText)
+        ]
 
 showAndFail :: Text -> IO a
 showAndFail msg = do


### PR DESCRIPTION
Allow building with optparse-applicative 0.18 and brick 2.

`vty-unix` is broken on nixpkgs master and `haskell-language-server` is broken on `haskell-updates`, so the flake's development shell is broken for now.