### PR TITLE
Allow passing `--store` for alternative nix store (e.g. remote binary cache)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@ Interactively browse dependency graphs of Nix derivations.
 `nix-tree` is on `nixpkgs` since `20.09`, so just use your preferred method for adding packages to your system, eg:
 
 ```
-nix-env -i nix-tree
+nix-env -iA nix-tree
+```
+
+Or, for flake enabled systems:
+
+```
+nix profile install 'nixpkgs#nix-tree'
 ```
 
 To run the current development version:
@@ -23,17 +29,20 @@ nix run github:utdemir/nix-tree -- --help
 
 ## Usage
 
-```
+```console
 $ nix-tree --help
-Usage: nix-tree [--version] [--derivation] [INSTALLABLE]
+Usage: nix-tree [INSTALLABLE] [--store STORE] [--version] [--derivation] [--impure]
+
   Interactively browse dependency graphs of Nix derivations.
 
 Available options:
-  --version                Show the nix-tree version.
-  --derivation             Operate on the store derivation rather than its
-                           outputs.
-  INSTALLABLE              A store path or a flake reference. Paths default to
-                           "~/.nix-profile" and "/var/run/current-system".
+  INSTALLABLE              A store path or a flake reference.
+                           Paths default to "~/.nix-profile" and "/var/run/current-system"
+  --store STORE            The URL of the Nix store, e.g. "daemon" or "https://cache.nixos.org"
+                           See "nix help-stores" for supported store types and settings.
+  --version                Show the nix-tree version
+  --derivation             Operate on the store derivation rather than its outputs
+  --impure                 Allow access to mutable paths and repositories
   -h,--help                Show this help text
 
 Keybindings:
@@ -66,12 +75,12 @@ with `| xargs -o nix-tree`. Examples:
 nix-build . --no-out-link | xargs -o nix-tree
 
 # Build time dependencies (passing a `.drv` path)
-nix-instantiate -r | xargs -o nix-tree --derivation
+nix-instantiate . | xargs -o nix-tree --derivation
 
 # Dependencies from shell.nix
 nix-build shell.nix -A inputDerivation | xargs -o nix-tree
 
-# All outputs of a derivation in nixpkgs:
+# All outputs of a derivation in nixpkgs
 nix-build '<nixpkgs>' -A openssl.all --no-out-link | xargs -o nix-tree
 ```
 
@@ -89,6 +98,20 @@ Run `nix-tree` on your current nixos system:
 
 ```bash
 nix-tree /nix/var/nix/profiles/system
+```
+
+Query the binary cache before download, with the `--store` option:
+
+```bash
+# Query the runtime dependency of `stellarium` (2 GiB closure) without download
+nix eval --raw 'nixpkgs#stellarium.outPath' | xargs -o nix-tree --store https://cache.nixos.org
+```
+
+For valid `--store` options, see [`nix help-stores`](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-help-stores). For example,
+
+```bash
+# Build in a temporary chroot store and examine the output
+nix build --store /tmp/chroot-store 'nixpkgs#hello' --print-out-paths | xargs -o nix-tree --store /tmp/chroot-store
 ```
 
 ## Contributing

--- a/src/NixTree/Main.hs
+++ b/src/NixTree/Main.hs
@@ -19,6 +19,7 @@ version = VERSION_nix_tree
 
 data Opts = Opts
   { oInstallables :: [Installable],
+    oStore :: String,
     oVersion :: Bool,
     oDerivation :: Bool,
     oImpure :: Bool
@@ -47,6 +48,18 @@ optsParser =
                               "Paths default to \"~/.nix-profile\" and \"/var/run/current-system\""
                             ]
                       )
+                )
+          )
+        <*> Opts.strOption
+          ( Opts.long "store"
+              <> Opts.metavar "STORE"
+              <> Opts.value "auto"
+              <> Opts.helpDoc
+                ( Just $
+                    Opts.vsep
+                      [ "The URL of the Nix store, e.g. \"daemon\" or \"https://cache.nixos.org\"",
+                        "See \"nix help-stores\" for supported store types and settings."
+                      ]
                 )
           )
         <*> Opts.switch (Opts.long "version" <> Opts.help "Show the nix-tree version")
@@ -96,7 +109,8 @@ main = do
   let seo =
         StoreEnvOptions
           { seoIsDerivation = opts & oDerivation,
-            seoIsImpure = opts & oImpure
+            seoIsImpure = opts & oImpure,
+            seoStoreURL = opts & oStore
           }
 
   withStoreEnv seo installables $ \env' -> do


### PR DESCRIPTION
Add an optional `--store` flag, which is passed to `nix path-info`. This enables us to query some remote store, e.g. the binary cache, with:
```bash
# dependency of jetbrains.pycharm-community (2 GiB closure)
nix-tree --store https://cache.nixos.org "$(nix eval --raw nixpkgs#jetbrains.pycharm-community)"
```
... without building a package locally.

Previously, I could obtain the closure of e.g. `nixpkgs#hello` without building it:
```console
$ nix eval --raw nixpkgs#hello | xargs nix path-info -rSh --store https://cache.nixos.org | sort -hk2
/nix/store/ayg5rhjhi9ic73hqw33mjqjxwv59ndym-xgcc-13.2.0-libgcc	 156.4K
/nix/store/05zbwhz8a7i2v79r9j21pl6m6cj0xi8k-libunistring-1.1  	   1.7M
/nix/store/m59xdgkgnjbk8kk6k6vbxmqnf82mk9s0-libidn2-2.3.4     	   2.1M
/nix/store/p3jshbwxiwifm1py0yq544fmdyy98j8a-glibc-2.38-27     	  31.1M
/nix/store/h92a9jd0lhhniv2q417hpwszd4jhys7q-hello-2.12.1      	  31.3M
```
But the dependency tree is flattened in the final output. This PR brings the power of `nix-tree` to binary caches as well.

**Warning:** I have no idea what I am doing. I have never written haskell before, and this is pieced together with the help of some LLM and the haskell language server. Please review the changes and see if it's okay!