### PR TITLE
Move to newer Haskell packageset

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -38,16 +38,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704626572,
-        "narHash": "sha256-VwRTEKzK4wSSv64G+g3RLF3t6yBHrhR2VK3kZ5UWisU=",
+        "lastModified": 1705436276,
+        "narHash": "sha256-X935ABMLp0pcCxlYaYoZBdhqlH6YqQvToD/GJuLElU8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "24fe8bb4f552ad3926274d29e083b79d84707da6",
+        "rev": "bb0e433d0116ba71b9a4ae0f8ff3ffcf26784cb1",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
+        "ref": "haskell-updates",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,7 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    # Temporary until `haskell-updates` is merged. Move it back to `nixpkgs-unstable` once it is.
+    nixpkgs.url = "github:nixos/nixpkgs/haskell-updates";
     flake-utils.url = "github:numtide/flake-utils/main";
     flake-compat = {
       url = "github:edolstra/flake-compat/master";

--- a/nix-tree.cabal
+++ b/nix-tree.cabal
@@ -48,7 +48,7 @@ common common-options
   build-depends:      base
                     , relude
                     , aeson
-                    , brick >= 1 && < 2
+                    , brick >= 2.1 && < 2.4
                     , bytestring
                     , containers
                     , clock

--- a/src/NixTree/App.hs
+++ b/src/NixTree/App.hs
@@ -134,9 +134,7 @@ run env = do
       return ()
 
   -- And run the application
-  let mkVty = V.mkVty V.defaultConfig
-  initialVty <- mkVty
-  _ <- B.customMain initialVty mkVty (Just chan) app appEnv
+  _ <- B.customMainWithDefaultVty (Just chan) app appEnv
 
   return ()
 

--- a/src/NixTree/Main.hs
+++ b/src/NixTree/Main.hs
@@ -42,9 +42,9 @@ optsParser =
                 ( Opts.metavar "INSTALLABLE"
                     <> Opts.helpDoc
                       ( Just $
-                          Opts.vsep 
-                            [ "A store path or a flake reference."
-                            , "Paths default to \"~/.nix-profile\" and \"/var/run/current-system\""
+                          Opts.vsep
+                            [ "A store path or a flake reference.",
+                              "Paths default to \"~/.nix-profile\" and \"/var/run/current-system\""
                             ]
                       )
                 )
@@ -56,8 +56,8 @@ optsParser =
     keybindingsHelp :: Opts.Doc
     keybindingsHelp =
       Opts.vsep
-        [ "Keybindings:"
-        , Opts.indent 2 . Opts.vsep $ map Opts.pretty (lines helpText)
+        [ "Keybindings:",
+          Opts.indent 2 . Opts.vsep $ map Opts.pretty (lines helpText)
         ]
 
 showAndFail :: Text -> IO a

--- a/src/NixTree/Main.hs
+++ b/src/NixTree/Main.hs
@@ -42,8 +42,10 @@ optsParser =
                 ( Opts.metavar "INSTALLABLE"
                     <> Opts.helpDoc
                       ( Just $
-                          "A store path or a flake reference."
-                            Opts.<$$> "Paths default to \"~/.nix-profile\" and \"/var/run/current-system\""
+                          Opts.vsep 
+                            [ "A store path or a flake reference."
+                            , "Paths default to \"~/.nix-profile\" and \"/var/run/current-system\""
+                            ]
                       )
                 )
           )
@@ -53,8 +55,10 @@ optsParser =
 
     keybindingsHelp :: Opts.Doc
     keybindingsHelp =
-      "Keybindings:"
-        Opts.<$$> (Opts.indent 2 . Opts.vsep $ map (Opts.text . toString) (lines helpText))
+      Opts.vsep
+        [ "Keybindings:"
+        , Opts.indent 2 . Opts.vsep $ map Opts.pretty (lines helpText)
+        ]
 
 showAndFail :: Text -> IO a
 showAndFail msg = do


### PR DESCRIPTION
`nix-tree` is broken on `haskell-updates` branch right now: https://github.com/NixOS/nixpkgs/pull/279413

This updates `brick` and `optparse-applicative` so it is updated there.