### PR TITLE
docs: add an example showing how to run nix-tree on a nixosConfiguration flake reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ Run `nix-tree` on your current nixos system:
 nix-tree /nix/var/nix/profiles/system
 ```
 
+Run `nix-tree` on a flake reference of a nixosConfiguration:
+
+```bash
+nix build --print-out-paths --no-link '.#nixosConfigurations.foo.config.system.build.toplevel'
+nix-tree '.#nixosConfigurations.foo.config.system.build.toplevel'
+```
+
 Query the binary cache before download, with the `--store` option:
 
 ```bash


### PR DESCRIPTION
Hi. The docs already show simple examples of how to run nix-tree on a flake reference _or_ on the current nixos system:

https://github.com/utdemir/nix-tree/blob/f735021f0b2df4121093d25ad4106baf6bfabfab/README.md?plain=1#L98-L102

But running it on a flake reference of a nixosConfiguration like this...

```nix
# flake.nix
{
  nixosConfigurations = {
    foo = nixpkgs.lib.nixosSystem { };
  };
}
```

...is slightly less intuitive.

This PR adds a simple example of how that can be done.
