### PR TITLE
Support for Home/End keys to jump to the beginning/end of why-depend modal lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* feat: support jumping to beginning/end of line (Home/End keys) in why-depends modal
+
 ## 0.7.0 - 2025-10-13:
 
 * feat: Now available as a Haskell library (thanks @MangoIV (issue: [#84]), @blackheaven (PR: [#129]))
@@ -60,7 +64,7 @@
 
 ## 0.3.3 - 2024-01-17:
 
-* chore: Update 'brick' & 'optparse-applicative' library to work with the newer Stackage snapshot (thanks @ncfavier, PR: [#78][]) 
+* chore: Update 'brick' & 'optparse-applicative' library to work with the newer Stackage snapshot (thanks @ncfavier, PR: [#78][])
 
 [#78]: https://github.com/utdemir/nix-tree/issues/78
 
@@ -73,14 +77,14 @@
 
 ## 0.3.1 - 2022-12-10:
 
-* fix: Update 'brick' library (thanks @ncfavier, PR: [#47][]) 
+* fix: Update 'brick' library (thanks @ncfavier, PR: [#47][])
 
 [#47]: https://github.com/utdemir/nix-tree/issues/47
 
 ## 0.3.0 - 2022-11-26:
 
 * feat: Improved help text.
-* feat: Allow passing '--impure' flag to Nix (issue: [#40][]) 
+* feat: Allow passing '--impure' flag to Nix (issue: [#40][])
 * fix: Use -O1 instead of -O2 to save on compile times.
 
 [#40]: https://github.com/utdemir/nix-tree/issues/40

--- a/app/NixTree/BrickApp.hs
+++ b/app/NixTree/BrickApp.hs
@@ -12,7 +12,7 @@ import qualified Data.Sequence as S
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Graphics.Vty as V
-import Lens.Micro (Traversal', _Just)
+import Lens.Micro (Traversal', _1, _Just, (^.))
 import qualified NixTree.Clipboard as Clipboard
 import NixTree.Data.InvertedIndex
 import NixTree.PathStats
@@ -258,6 +258,12 @@ app =
           (B.VtyEvent (V.EvKey k []), Just (ModalWhyDepends _))
             | k `elem` [V.KChar 'l', V.KRight] ->
                 B.hScrollBy (B.viewportScroll WidgetWhyDependsViewport) 1
+          (B.VtyEvent (V.EvKey k []), Just (ModalWhyDepends _))
+            | k == V.KHome ->
+                B.hScrollToBeginning (B.viewportScroll WidgetWhyDependsViewport)
+          (B.VtyEvent (V.EvKey k []), Just (ModalWhyDepends l))
+            | k == V.KEnd ->
+                scrollToSelectedLineEnd l
           (B.VtyEvent (V.EvKey V.KPageUp []), Just (ModalWhyDepends _)) ->
             B.zoom (aeOpenModalL . _Just . _ModalWhyDepends) B.listMovePageUp
           (B.VtyEvent (V.EvKey V.KPageDown []), Just (ModalWhyDepends _)) ->
@@ -448,12 +454,35 @@ renderWhyDependsModal l =
     & renderModal "why-depends"
   where
     renderDepends _ =
-      B.txt . pathsToText
-    pathsToText xs =
-      xs
-        & NE.toList
-        & fmap (storeNameToShortText . spName)
-        & T.intercalate " → "
+      B.txt . whyDependsPathToText
+
+whyDependsPathToText :: NonEmpty Path -> Text
+whyDependsPathToText xs =
+  xs
+    & NE.toList
+    & fmap (storeNameToShortText . spName)
+    & T.intercalate " → "
+
+{- We could use 'B.hScrollToEnd', but it jumps too much when some lines are longer than others.
+This is more fine grained in that it jumps only to the end of the currently selected line.
+-}
+scrollToSelectedLineEnd ::
+  B.GenericList Widgets Seq (NonEmpty Path) ->
+  B.EventM Widgets (AppEnv s) ()
+scrollToSelectedLineEnd l = do
+  mViewport <- B.lookupViewport WidgetWhyDependsViewport
+  case (mViewport, B.listSelectedElement l) of
+    (Just vp, Just (_, selectedPath')) -> do
+      let textWidth = B.textWidth (whyDependsPathToText selectedPath')
+          viewportWidth = vp ^. B.vpSize . _1
+          currentScroll = vp ^. B.vpLeft
+          -- Calculate the scroll position needed to right-align the selected line
+          -- We want: scrollPos + viewportWidth >= textWidth
+          -- So: scrollPos = textWidth - viewportWidth (but not less than 0)
+          targetScroll = max 0 (textWidth - viewportWidth)
+          scrollDelta = targetScroll - currentScroll
+      B.hScrollBy (B.viewportScroll WidgetWhyDependsViewport) scrollDelta
+    _ -> pass
 
 showWhyDepends :: AppEnv s -> AppEnv s
 showWhyDepends env@AppEnv {aeActualStoreEnv} =


### PR DESCRIPTION
Thank you for this wonderful tool.
It's a big time saver for me.

When using I realized realized I'm spending a lot of time pressing and holding left-right arrows to scroll to the end of individual lines of the why-depends modal. It would be great if I could use Home and End keys to speed that up.
Compare the UX before and after this PR:

before
![nix-tree-before](https://github.com/user-attachments/assets/da62e90c-c6f2-44b6-96e6-223879543f75)

after
![nix-tree-after](https://github.com/user-attachments/assets/62805c2e-dddb-49d7-b5b6-65983e7251a9)
