### PR TITLE
Ctrl+C to exit

### DIFF
--- a/app/NixTree/BrickApp.hs
+++ b/app/NixTree/BrickApp.hs
@@ -203,6 +203,9 @@ app =
       B.appHandleEvent = \e -> do
         s <- get
         case (e, aeOpenModal s) of
+          -- quit
+          (B.VtyEvent (V.EvKey (V.KChar 'c') [V.MCtrl]), _) ->
+            B.halt
           -- main screen
           (B.VtyEvent (V.EvKey k []), Nothing)
             | k `elem` [V.KChar 'q', V.KEsc] ->


### PR DESCRIPTION
Not sure if this is controversial, but coming from TUIs like ncdu, I intuitively expect Ctrl+C to close the application. This PR makes nix-tree match that behavior.