### PR TITLE
Remove $XDG_STATE_HOME/nix/profiles/home-manager from default installables

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -119,13 +119,11 @@ main = do
     [] -> do
       home <- getHomeDirectory
       nixXdgDirectory <- getXdgDirectory XdgState "nix/profile"
-      homeManagerDirectory <- getXdgDirectory XdgState "nix/profiles/home-manager"
       roots <-
         filterM
           isValidRoot
           [ home </> ".nix-profile",
             nixXdgDirectory,
-            homeManagerDirectory,
             "/var/run/current-system"
           ]
       case roots of


### PR DESCRIPTION
The default behaviour of nix-tree on my system is confusing. According to `nix-tree --help`, the default store paths are `~/.nix-profile` and `/var/run/current-system`. However, in https://github.com/utdemir/nix-tree/pull/110, an additional path, `$XDG_STATE_HOME/nix/profiles/home-manager`, was added.

I am using home-manager standalone with flakes. As I understand it, running `home-manager switch` creates a profile which is symlinked to `$XDG_STATE_HOME/nix/profiles/home-manager`, and ["activates" it by running `nix profile install`](https://github.com/nix-community/home-manager/blob/bb014746edb2a98d975abde4dd40fa240de4cf86/modules/home-environment.nix#L719). This means that the current user profile at `~/.nix-profile` contains your home-manager configuration as well as any other packages installed imperatively with `nix profile`. By default, nix-tree will display both `~/.nix-profile` and `$XDG_STATE_HOME/nix/profiles/home-manager`. In the common case where there are no imperatively-installed packages, they will be almost identical and each will have an "added size" which is trivially small. This is confusing, especially on NixOS where the profile at `/var/run/current-system` is also displayed, because it suggests that the `home-manager` profile adds little to the system configuration. Plus, it's inconsistent with the help text.

I think the default behaviour should be as specified in the help text. If the user is using home-manager, it will be included in the tree of their current profile. The rationale seems to be that home-manager was doing "weird things" in https://github.com/utdemir/nix-tree/issues/106, but I can't reproduce the observed behaviour of `$XDG_STATE_HOME/nix/profiles/profile` (the equivalent of `~/.nix-profile` when `use-xdg-base-directories` is enabled) being a directory rather than a symlink, which as noted in https://github.com/utdemir/nix-tree/pull/71#issuecomment-2581486292, is contrary to the Nix documentation and may be a misconfiguration.